### PR TITLE
Ensure single ending trailing slash for joining location path

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -2,7 +2,7 @@
   'use strict';
 
   var pathRX = new RegExp(/\/[^\/]+$/)
-    , locationPath = location.pathname.replace(pathRX, '');
+    , locationPath = location.pathname.replace(pathRX, '/');
 
   require({
     async: true,


### PR DESCRIPTION
This fixes a problem where accessing /index.html does not work correctly.
